### PR TITLE
Add numpy 2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,10 @@ jobs:
         run: |
           python -m pylint src/pentapy/
 
+      - name: cython-lint check
+        run: |
+          cython-lint src/pentapy/
+
   build_wheels:
     name: wheels for ${{ matrix.cfg.os }} / ${{ matrix.cfg.arch }}
     runs-on: ${{ matrix.cfg.os }}
@@ -50,9 +54,7 @@ jobs:
       matrix:
         cfg:
         - { os: ubuntu-latest, arch: x86_64 }
-        - { os: ubuntu-latest, arch: i686 }
         - { os: windows-latest, arch: AMD64 }
-        - { os: windows-latest, arch: x86 }
         - { os: macos-latest, arch: x86_64 }
         - { os: macos-latest, arch: arm64 }
         - { os: macos-latest, arch: universal2 }
@@ -63,7 +65,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_ARCHS: ${{ matrix.cfg.arch }}
         with:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/source/conf.py
 
 formats: all
 
 python:
-  version: 3.7
   install:
     - method: pip
       path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to **pentapy** will be documented in this file.
 
 
+## [1.3.0] - 2024-04
+
+See [#21](https://github.com/GeoStat-Framework/pentapy/pull/21)
+
+### Enhancements
+- added support for python 3.12
+- added support for numpy 2
+- build extensions with numpy 2 and cython 3
+
+### Changes
+- dropped python 3.7 support
+- dropped 32bit builds
+- linted cython files
+- increase maximal line length to 88 (black default)
+
+
 ## [1.2.0] - 2023-04
 
 See [#19](https://github.com/GeoStat-Framework/pentapy/pull/19)
@@ -15,7 +31,7 @@ See [#19](https://github.com/GeoStat-Framework/pentapy/pull/19)
 
 ### Changes
 - move to `src/` based package structure
-- dropped python 3.7 support
+- dropped python 3.6 support
 - move meta-data to pyproject.toml
 - simplified documentation
 
@@ -84,6 +100,7 @@ This is the first release of pentapy, a python toolbox for solving pentadiagonal
 The solver is implemented in cython, which makes it really fast.
 
 
+[1.3.0]: https://github.com/GeoStat-Framework/pentapy/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/GeoStat-Framework/pentapy/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/GeoStat-Framework/pentapy/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/GeoStat-Framework/pentapy/compare/v1.1.0...v1.1.1

--- a/examples/01_solve.py
+++ b/examples/01_solve.py
@@ -9,6 +9,7 @@ After solving we calculate the absolute difference between the right hand side
 and the product of the matrix (which is transformed to a full quadratic one)
 and the solution of the system.
 """
+
 import numpy as np
 
 import pentapy as pp

--- a/examples/02_compare.py
+++ b/examples/02_compare.py
@@ -5,6 +5,7 @@
 Here we compare the outcome of the PTRANS-I and PTRANS-II algorithm for
 a random input.
 """
+
 import numpy as np
 
 import pentapy as pp

--- a/examples/03_perform_simple.py
+++ b/examples/03_perform_simple.py
@@ -11,6 +11,7 @@ To use this script you need to have the following packages installed:
     * perfplot
     * matplotlib
 """
+
 import numpy as np
 import perfplot
 

--- a/examples/04_perform_full_mat.py
+++ b/examples/04_perform_full_mat.py
@@ -11,6 +11,7 @@ To use this script you need to have the following packages installed:
     * perfplot
     * matplotlib
 """
+
 import numpy as np
 import perfplot
 

--- a/examples/05_solve_error.py
+++ b/examples/05_solve_error.py
@@ -5,6 +5,7 @@
 Here we demonstrate that the solver PTRANS-I can fail to solve a given system.
 A warning is given in that case and the output will be a nan-array.
 """
+
 import numpy as np
 
 import pentapy as pp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ doc = [
 ]
 test = ["pytest-cov>=3"]
 check = [
-  "black>=23,<24",
+  "black>=24,<25",
   "isort[colors]",
   "pylint",
   "cython-lint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [build-system]
 requires = [
     "setuptools>=64",
-    "wheel",
     "setuptools_scm>=7",
-    "oldest-supported-numpy",
-    "Cython>=0.29.32,<3.0",
+    "numpy>=2.0.0rc1,<2.3; python_version >= '3.9'",
+    "oldest-supported-numpy; python_version < '3.9'",
+    "Cython>=3.0.10,<3.1.0",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 name = "pentapy"
 authors = [{name = "Sebastian Müller", email = "info@geostat-framework.org"}]
 readme = "README.md"
@@ -26,15 +26,16 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Utilities",
 ]
-dependencies = ["numpy>=1.14.5"]
+dependencies = ["numpy>=1.20.0"]
 
 [project.optional-dependencies]
 scipy = ["scipy"]
@@ -49,15 +50,16 @@ doc = [
     "matplotlib>=3",
     "perfplot<0.9",
     "numpydoc>=1.1",
-    "sphinx>=4",
+    "sphinx>=7",
     "sphinx-gallery>=0.8",
-    "sphinx-rtd-theme>=1,<1.1",
+    "sphinx-rtd-theme>=2",
 ]
 test = ["pytest-cov>=3"]
 check = [
   "black>=23,<24",
-  "isort[colors]<6",
-  "pylint<3",
+  "isort[colors]",
+  "pylint",
+  "cython-lint",
 ]
 
 [project.urls]
@@ -80,11 +82,18 @@ fallback_version = "0.0.0.dev0"
 [tool.isort]
 profile = "black"
 multi_line_output = 3
-line_length = 79
 
 [tool.black]
-line-length = 79
-target-version = ["py37"]
+target-version = [
+    "py38",
+    "py39",
+    "py310",
+    "py311",
+    "py312",
+]
+
+[tool.cython-lint]
+max-line-length = 120
 
 [tool.coverage]
     [tool.coverage.run]
@@ -130,12 +139,10 @@ target-version = ["py37"]
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
-# Disable building PyPy wheels on all platforms, 32bit for py3.10/11 and musllinux builds, py3.6
-skip = ["cp36-*", "pp*", "cp31*-win32", "cp31*-manylinux_i686", "*-musllinux_*"]
+# Disable building PyPy wheels on all platforms, 32bit builds, py3.6, py3.7
+skip = ["cp36-*", "cp37-*", "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs
 test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
-# no wheels for linux-32bit anymore for numpy>=1.22
-environment = "PIP_PREFER_BINARY=1"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """pentapy: A toolbox for pentadiagonal matrizes."""
+
 import os
 
 import numpy as np

--- a/src/pentapy/__init__.py
+++ b/src/pentapy/__init__.py
@@ -40,12 +40,7 @@ The following tools are provided:
 """
 
 from pentapy.core import solve
-from pentapy.tools import (
-    create_banded,
-    create_full,
-    diag_indices,
-    shift_banded,
-)
+from pentapy.tools import create_banded, create_full, diag_indices, shift_banded
 
 try:
     from pentapy._version import __version__

--- a/src/pentapy/__init__.py
+++ b/src/pentapy/__init__.py
@@ -38,6 +38,7 @@ The following tools are provided:
    create_banded
    create_full
 """
+
 from pentapy.core import solve
 from pentapy.tools import (
     create_banded,

--- a/src/pentapy/core.py
+++ b/src/pentapy/core.py
@@ -1,4 +1,5 @@
 """The core module of pentapy."""
+
 # pylint: disable=C0103, C0415, R0911, E0611
 import warnings
 
@@ -102,8 +103,7 @@ def solve(mat, rhs, is_flat=False, index_row_wise=True, solver=1):
             from scipy.linalg import solve_banded
         except ImportError as imp_err:  # pragma: no cover
             raise ValueError(
-                "pentapy.solve: "
-                "scipy.linalg.solve_banded could not be imported"
+                "pentapy.solve: " "scipy.linalg.solve_banded could not be imported"
             ) from imp_err
         if is_flat and index_row_wise:
             mat_flat = np.array(mat)

--- a/src/pentapy/core.py
+++ b/src/pentapy/core.py
@@ -102,9 +102,8 @@ def solve(mat, rhs, is_flat=False, index_row_wise=True, solver=1):
         try:
             from scipy.linalg import solve_banded
         except ImportError as imp_err:  # pragma: no cover
-            raise ValueError(
-                "pentapy.solve: " "scipy.linalg.solve_banded could not be imported"
-            ) from imp_err
+            msg = "pentapy.solve: scipy.linalg.solve_banded could not be imported"
+            raise ValueError(msg) from imp_err
         if is_flat and index_row_wise:
             mat_flat = np.array(mat)
             _check_penta(mat_flat)
@@ -119,9 +118,8 @@ def solve(mat, rhs, is_flat=False, index_row_wise=True, solver=1):
             from scipy import sparse as sps
             from scipy.sparse.linalg import spsolve
         except ImportError as imp_err:
-            raise ValueError(
-                "pentapy.solve: scipy.sparse could not be imported"
-            ) from imp_err
+            msg = "pentapy.solve: scipy.sparse could not be imported"
+            raise ValueError(msg) from imp_err
         if is_flat and index_row_wise:
             mat_flat = np.array(mat)
             _check_penta(mat_flat)
@@ -144,9 +142,8 @@ def solve(mat, rhs, is_flat=False, index_row_wise=True, solver=1):
             from scipy import sparse as sps
             from scipy.sparse.linalg import spsolve
         except ImportError as imp_err:
-            raise ValueError(
-                "pentapy.solve: scipy.sparse could not be imported"
-            ) from imp_err
+            msg = "pentapy.solve: scipy.sparse could not be imported"
+            raise ValueError(msg) from imp_err
         if is_flat and index_row_wise:
             mat_flat = np.array(mat)
             _check_penta(mat_flat)
@@ -159,4 +156,5 @@ def solve(mat, rhs, is_flat=False, index_row_wise=True, solver=1):
         M = sps.spdiags(mat_flat, [2, 1, 0, -1, -2], size, size, format="csc")
         return spsolve(M, rhs, use_umfpack=True)
     else:  # pragma: no cover
-        raise ValueError("pentapy.solve: unknown solver (" + str(solver) + ")")
+        msg = f"pentapy.solve: unknown solver ({solver})"
+        raise ValueError(msg)

--- a/src/pentapy/solver.pxd
+++ b/src/pentapy/solver.pxd
@@ -1,4 +1,4 @@
-#cython: language_level=3
-cdef double[:] c_penta_solver1(double[:,:] mat_flat, double[:] rhs)
+# cython: language_level=3
+cdef double[:] c_penta_solver1(double[:, :] mat_flat, double[:] rhs)
 
-cdef double[:] c_penta_solver2(double[:,:] mat_flat, double[:] rhs)
+cdef double[:] c_penta_solver2(double[:, :] mat_flat, double[:] rhs)

--- a/src/pentapy/solver.pyx
+++ b/src/pentapy/solver.pyx
@@ -1,23 +1,22 @@
-#cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """
 This is a solver linear equation systems with a penta-diagonal matrix,
 implemented in cython.
 """
 import numpy as np
 
-cimport cython
 cimport numpy as np
 
 
-def penta_solver1(double[:,:] mat_flat, double[:] rhs):
+def penta_solver1(double[:, :] mat_flat, double[:] rhs):
     return np.asarray(c_penta_solver1(mat_flat, rhs))
 
 
-def penta_solver2(double[:,:] mat_flat, double[:] rhs):
+def penta_solver2(double[:, :] mat_flat, double[:] rhs):
     return np.asarray(c_penta_solver2(mat_flat, rhs))
 
 
-cdef double[:] c_penta_solver1(double[:,:] mat_flat, double[:] rhs):
+cdef double[:] c_penta_solver1(double[:, :] mat_flat, double[:] rhs):
 
     cdef int mat_j = mat_flat.shape[1]
 
@@ -69,7 +68,7 @@ cdef double[:] c_penta_solver1(double[:,:] mat_flat, double[:] rhs):
     return result
 
 
-cdef double[:] c_penta_solver2(double[:,:] mat_flat, double[:] rhs):
+cdef double[:] c_penta_solver2(double[:, :] mat_flat, double[:] rhs):
 
     cdef int mat_j = mat_flat.shape[1]
 

--- a/src/pentapy/tools.py
+++ b/src/pentapy/tools.py
@@ -172,9 +172,11 @@ def create_banded(mat, up=2, low=2, col_wise=True, dtype=None):
     """
     mat = np.asanyarray(mat)
     if mat.ndim != 2:
-        raise ValueError("create_banded: matrix has to be 2D")
+        msg = "create_banded: matrix has to be 2D"
+        raise ValueError(msg)
     if mat.shape[0] != mat.shape[1]:
-        raise ValueError("create_banded: matrix has to be n x n")
+        msg = "create_banded: matrix has to be n x n"
+        raise ValueError(msg)
 
     size = mat.shape[0]
     mat_flat = np.zeros((5, size), dtype=dtype)
@@ -244,11 +246,14 @@ def create_full(mat, up=2, low=2, col_wise=True):
     """
     mat = np.asanyarray(mat)
     if mat.ndim != 2:
-        raise ValueError("create_full: matrix has to be 2D")
+        msg = "create_full: matrix has to be 2D"
+        raise ValueError(msg)
     if mat.shape[0] != up + low + 1:
-        raise ValueError("create_full: matrix has wrong count of bands")
+        msg = "create_full: matrix has wrong count of bands"
+        raise ValueError(msg)
     if mat.shape[1] < max(up, low) + 1:
-        raise ValueError("create_full: matrix has to few information")
+        msg = "create_full: matrix has to few information"
+        raise ValueError(msg)
     size = mat.shape[1]
     mat_full = np.diag(mat[up])
     if col_wise:
@@ -266,8 +271,11 @@ def create_full(mat, up=2, low=2, col_wise=True):
 
 def _check_penta(mat):
     if mat.ndim != 2:
-        raise ValueError("pentapy: matrix has to be 2D")
+        msg = "pentapy: matrix has to be 2D"
+        raise ValueError(msg)
     if mat.shape[0] != 5:
-        raise ValueError("pentapy: matrix needs 5 bands")
+        msg = "pentapy: matrix needs 5 bands"
+        raise ValueError(msg)
     if mat.shape[1] < 3:
-        raise ValueError("pentapy: matrix needs at least 3 rows")
+        msg = "pentapy: matrix needs at least 3 rows"
+        raise ValueError(msg)

--- a/src/pentapy/tools.py
+++ b/src/pentapy/tools.py
@@ -13,6 +13,7 @@ The following functions are provided
    create_banded
    create_full
 """
+
 # pylint: disable=C0103
 import numpy as np
 
@@ -254,9 +255,7 @@ def create_full(mat, up=2, low=2, col_wise=True):
         for i in range(up):
             mat_full[diag_indices(size, up - i)] = mat[i, (up - i) :]
         for i in range(low):
-            mat_full[diag_indices(size, -(low - i))] = mat[
-                -i - 1, : -(low - i)
-            ]
+            mat_full[diag_indices(size, -(low - i))] = mat[-i - 1, : -(low - i)]
     else:
         for i in range(up):
             mat_full[diag_indices(size, up - i)] = mat[i, : -(up - i)]

--- a/tests/test_pentapy.py
+++ b/tests/test_pentapy.py
@@ -1,6 +1,7 @@
 """
 This is the unittest for pentapy.
 """
+
 import unittest
 
 # import platform
@@ -24,21 +25,11 @@ class TestPentapy(unittest.TestCase):
     def test_tools(self):
         self.mat_int = np.zeros((100, 100), dtype=int)
         # fill bands of pentadiagonal matrix
-        self.mat_int[pp.diag_indices(100, 0)] = self.rand.randint(
-            1, 1000, size=100
-        )
-        self.mat_int[pp.diag_indices(100, 1)] = self.rand.randint(
-            1, 1000, size=99
-        )
-        self.mat_int[pp.diag_indices(100, 2)] = self.rand.randint(
-            1, 1000, size=98
-        )
-        self.mat_int[pp.diag_indices(100, -1)] = self.rand.randint(
-            1, 1000, size=99
-        )
-        self.mat_int[pp.diag_indices(100, -2)] = self.rand.randint(
-            1, 1000, size=98
-        )
+        self.mat_int[pp.diag_indices(100, 0)] = self.rand.randint(1, 1000, size=100)
+        self.mat_int[pp.diag_indices(100, 1)] = self.rand.randint(1, 1000, size=99)
+        self.mat_int[pp.diag_indices(100, 2)] = self.rand.randint(1, 1000, size=98)
+        self.mat_int[pp.diag_indices(100, -1)] = self.rand.randint(1, 1000, size=99)
+        self.mat_int[pp.diag_indices(100, -2)] = self.rand.randint(1, 1000, size=98)
         # create banded
         self.mat_int_col = pp.create_banded(self.mat_int)
         self.mat_int_row = pp.create_banded(self.mat_int, col_wise=False)
@@ -80,9 +71,7 @@ class TestPentapy(unittest.TestCase):
         diff_col = np.max(np.abs(np.dot(self.mat_ful, sol_col) - self.rhs))
         diff_ful = np.max(np.abs(np.dot(self.mat_ful, sol_ful) - self.rhs))
 
-        diff_row_col = np.max(
-            np.abs(self.mat_ful - pp.create_full(self.mat_col))
-        )
+        diff_row_col = np.max(np.abs(self.mat_ful - pp.create_full(self.mat_col)))
         self.assertAlmostEqual(diff_row * 1e-5, 0.0)
         self.assertAlmostEqual(diff_col * 1e-5, 0.0)
         self.assertAlmostEqual(diff_ful * 1e-5, 0.0)
@@ -106,9 +95,7 @@ class TestPentapy(unittest.TestCase):
         diff_col = np.max(np.abs(np.dot(self.mat_ful, sol_col) - self.rhs))
         diff_ful = np.max(np.abs(np.dot(self.mat_ful, sol_ful) - self.rhs))
 
-        diff_row_col = np.max(
-            np.abs(self.mat_ful - pp.create_full(self.mat_col))
-        )
+        diff_row_col = np.max(np.abs(self.mat_ful - pp.create_full(self.mat_col)))
         self.assertAlmostEqual(diff_row * 1e-5, 0.0)
         self.assertAlmostEqual(diff_col * 1e-5, 0.0)
         self.assertAlmostEqual(diff_ful * 1e-5, 0.0)


### PR DESCRIPTION
- build extensions with numpy 2 for py > 3.8
- drop 32bit builds
- lint cython files
- use 88 as max line length for black and isort
- update docs config